### PR TITLE
Solving window contiguous error

### DIFF
--- a/pytorch_ssim/__init__.py
+++ b/pytorch_ssim/__init__.py
@@ -8,10 +8,16 @@ def gaussian(window_size, sigma):
     gauss = torch.Tensor([exp(-(x - window_size/2)**2/float(2*sigma**2)) for x in range(window_size)])
     return gauss/gauss.sum()
 
+def to_variable(x):
+    """Convert tensor to variable."""
+    if torch.cuda.is_available():
+        x = x.cuda()
+    return Variable(x)
+
 def create_window(window_size, channel):
     _1D_window = gaussian(window_size, 1.5).unsqueeze(1)
     _2D_window = _1D_window.mm(_1D_window.t()).float().unsqueeze(0).unsqueeze(0)
-    window = Variable(_2D_window.expand(channel, 1, window_size, window_size))
+    window = to_variable(_2D_window.expand(channel, 1, window_size, window_size))
     return window
 
 def _ssim(img1, img2, window, window_size, channel, size_average = True):


### PR DESCRIPTION
Solving contiguous cudNN runtime error by transferring window to GPU first and then making it a variable. This problem is explained in issue[2](https://github.com/Po-Hsun-Su/pytorch-ssim/issues/2)