### PR TITLE
Remove unnecessary numpy dependency, replace math.exp w/ torch.exp

### DIFF
--- a/pytorch_ssim/__init__.py
+++ b/pytorch_ssim/__init__.py
@@ -1,11 +1,10 @@
 import torch
 import torch.nn.functional as F
 from torch.autograd import Variable
-import numpy as np
-from math import exp
 
 def gaussian(window_size, sigma):
-    gauss = torch.Tensor([exp(-(x - window_size//2)**2/float(2*sigma**2)) for x in range(window_size)])
+    gauss = torch.exp(torch.tensor(
+        [-(x - window_size//2)**2/float(2*sigma**2) for x in range(window_size)]))
     return gauss/gauss.sum()
 
 def create_window(window_size, channel):


### PR DESCRIPTION
I don't really know what works or doesn't with autograd/backward but I'm guessing it's better to use torch functions when available, and numpy is an unused import.